### PR TITLE
Bugfix: avatar animation obstructing buttons in control panel

### DIFF
--- a/src/frontend/components/Avatar/AvatarAnimation.vue
+++ b/src/frontend/components/Avatar/AvatarAnimation.vue
@@ -3,7 +3,7 @@
     class="avatar-animation"
     :style="{
       width: `${width}px`,
-      height: `${width}px`,
+      height: `${height}px`,
     }"
   >
     <img
@@ -16,7 +16,7 @@
       v-else
       :style="{
         width: `${width}px`,
-        height: `${width}px`,
+        height: `${height}px`,
         display: 'inline-block',
       }"
     />


### PR DESCRIPTION
Bug: HTML Element containing Avatar Animation invisibly went over the buttons, obstructing them. Buttons could not be pressed. This happened only for horizontally elongated avatars.

Solution: Height was mistakenly assigned to width in a Vue file's template section.

![image](https://github.com/user-attachments/assets/067472c7-deca-4394-a3c8-17d8a8a6c303)
