### PR TITLE
fix: stop ws auth reconnect loop and scope init timing logs

### DIFF
--- a/src/Timer.test.ts
+++ b/src/Timer.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Timer } from './Timer'
+
+describe('src/Timer.ts', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns incremental split times and total time', () => {
+    vi.spyOn(performance, 'now')
+      .mockReturnValueOnce(100) // reset()
+      .mockReturnValueOnce(115) // split()
+      .mockReturnValueOnce(160) // split()
+
+    const timer = new Timer()
+    timer.reset()
+
+    timer.split()
+    expect(timer.lastSplitMs()).toBe('15.00')
+    expect(timer.totalMs()).toBe('15.00')
+
+    timer.split()
+    expect(timer.lastSplitMs()).toBe('45.00')
+    expect(timer.totalMs()).toBe('60.00')
+  })
+
+  it('reset starts a fresh measurement window', () => {
+    vi.spyOn(performance, 'now')
+      .mockReturnValueOnce(200) // reset()
+      .mockReturnValueOnce(230) // split()
+      .mockReturnValueOnce(1000) // reset()
+      .mockReturnValueOnce(1040) // split()
+
+    const timer = new Timer()
+    timer.reset()
+    timer.split()
+    expect(timer.totalMs()).toBe('30.00')
+
+    timer.reset()
+    timer.split()
+    expect(timer.totalMs()).toBe('40.00')
+  })
+
+  it('returns NaN before at least one split after reset', () => {
+    vi.spyOn(performance, 'now')
+      .mockReturnValueOnce(50) // reset()
+
+    const timer = new Timer()
+    timer.reset()
+
+    expect(timer.lastSplitMs()).toBe('NaN')
+    expect(timer.totalMs()).toBe('NaN')
+  })
+})

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -167,6 +167,7 @@ const createBot = async (): Promise<Bot> => {
 // changes to user will be handled by user_changed event
 const initForUser = async (bot: Bot, user: User) => {
   const clientManager = bot.getUserTwitchClientManager(user)
+  const userLog = logger('bot.ts', `${user.name}(${user.id})|`)
   const timer = new Timer()
   timer.reset()
 
@@ -178,14 +179,14 @@ const initForUser = async (bot: Bot, user: User) => {
   //       startup will take forever
 
   timer.split()
-  log.debug(`initiating client manager took ${timer.lastSplitMs()}ms`)
+  userLog.debug(`initiating client manager took ${timer.lastSplitMs()}ms`)
 
   for (const moduleClass of modules) {
     bot.getModuleManager().add(user.id, await new moduleClass(bot, user))
   }
 
   timer.split()
-  log.debug(`initiating all modules took ${timer.lastSplitMs()}ms`)
+  userLog.debug(`initiating all modules took ${timer.lastSplitMs()}ms`)
 
   bot.getFrontendStatusUpdater().addUser(user)
   bot.getStreamStatusUpdater().addUser(user)
@@ -214,7 +215,8 @@ const initForUser = async (bot: Bot, user: User) => {
   })
 
   timer.split()
-  log.debug(`init for user took ${timer.totalMs()}ms`)
+  userLog.debug(`registering user event handlers took ${timer.lastSplitMs()}ms`)
+  userLog.debug(`init for user took ${timer.totalMs()}ms`)
 }
 
 export const run = async () => {

--- a/src/services/TwitchClientManager.ts
+++ b/src/services/TwitchClientManager.ts
@@ -112,19 +112,17 @@ class TwitchClientManager {
   }
 
   async init(reason: string) {
-    const timer = new Timer()
-    timer.reset()
-
     let connectReason = reason
     const cfg = this.bot.getConfig().twitch
     const user = this.user
 
     this.log = logger('TwitchClientManager.ts', `${user.name}|`)
 
-    await this._disconnectChatClient()
-
-    timer.split()
-    this.log.debug(`disconnecting chat client took ${timer.lastSplitMs()}ms`)
+    const disconnectTimer = new Timer()
+    disconnectTimer.reset()
+    this._disconnectChatClient()
+    disconnectTimer.split()
+    this.log.debug(`disconnecting chat client took ${disconnectTimer.lastSplitMs()}ms`)
 
     const identity = determineIdentity(user, cfg)
 
@@ -206,15 +204,19 @@ class TwitchClientManager {
         })
 
         enqueueChatConnectTask(async () => {
+          const connectTimer = new Timer()
+          connectTimer.reset()
+
           if (this.chatClient !== chatClient) {
+            this.log.debug('skipping stale queued chat connect task')
             return
           }
+
           await chatClient.connect()
+          connectTimer.split()
+          this.log.debug(`connecting chat client took ${connectTimer.lastSplitMs()}ms`)
         })
       }
-
-      timer.split()
-      this.log.debug(`connecting chat client took ${timer.lastSplitMs()}ms`)
     }
 
     // register EventSub
@@ -224,15 +226,18 @@ class TwitchClientManager {
       // queue in background with limited concurrency to prevent API bursts on startup.
       const helixClientForSubscriptions = this.helixClient
       enqueueBackgroundTask(async () => {
+        const subscriptionsTimer = new Timer()
+        subscriptionsTimer.reset()
+
         if (this.helixClient !== helixClientForSubscriptions) {
+          this.log.debug('skipping stale queued subscription registration task')
           return
         }
         await this.registerSubscriptions(this.user)
+        subscriptionsTimer.split()
+        this.log.debug(`registering subscriptions took ${subscriptionsTimer.lastSplitMs()}ms`)
       })
     }
-
-    timer.split()
-    this.log.debug(`registering subscriptions took ${timer.lastSplitMs()}ms`)
   }
 
   async registerSubscriptions(user: User) {
@@ -371,7 +376,7 @@ class TwitchClientManager {
     }
   }
 
-  private async _disconnectChatClient() {
+  private _disconnectChatClient() {
     if (this.chatClient) {
       this.chatClient.quit()
       this.chatClient = null


### PR DESCRIPTION
   - measure connect/subscription timing where queued tasks actually run
   - add per-user context to startup timing logs
   - add tests for WsWrapper reconnect behavior and Timer splits
